### PR TITLE
fix node-gyp build warning in v6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "README.md"
   ],
   "dependencies": {
-    "nan": "^2.8.0"
+    "nan": "^2.10.0"
   }
 }

--- a/src/heap_graph_node.cc
+++ b/src/heap_graph_node.cc
@@ -66,7 +66,7 @@ namespace nodex {
     Local<Object> graph_node;
     Local<Object> _cache = Nan::New(graph_node_cache);
     int32_t _id = node->GetId();
-    if (_cache->Has(_id)) {
+    if (_cache->Has(Nan::New<Number>(_id))) {
       graph_node = _cache->Get(_id)->ToObject();
     } else {
       graph_node = Nan::New(graph_node_template_)->NewInstance();

--- a/src/heap_output_stream.cc
+++ b/src/heap_output_stream.cc
@@ -9,7 +9,7 @@ namespace nodex {
   using v8::String;
   using v8::OutputStream;
   using v8::Function;
-  using v8::TryCatch;;
+  using Nan::TryCatch;;
   using v8::Integer;
 
   void OutputStreamAdapter::EndOfStream() {

--- a/src/heap_profiler.cc
+++ b/src/heap_profiler.cc
@@ -13,7 +13,7 @@ namespace nodex {
   using v8::Object;
   using v8::SnapshotObjectId;
   using v8::String;
-  using v8::TryCatch;
+  using Nan::TryCatch;
   using v8::Value;
 
   HeapProfiler::HeapProfiler() {}

--- a/src/sampling_heap_profile.cc
+++ b/src/sampling_heap_profile.cc
@@ -31,7 +31,6 @@ namespace nodex {
     js_node->Set(Nan::New<String>("callFrame").ToLocalChecked(), call_frame);
 
     // add self size
-    Local<Array> allocations = Nan::New<Array>(node->allocations.size());
     int selfSize = 0;
     for (size_t i = 0; i < node->allocations.size(); i++) {
       AllocationProfile::Allocation alloc = node->allocations[i];


### PR DESCRIPTION
fix node-gyp build warning in v6.x