### PR TITLE
src: support V8 v8.0.x.y

### DIFF
--- a/src/cpu_profile_node.cc
+++ b/src/cpu_profile_node.cc
@@ -53,7 +53,10 @@ Local<Value> ProfileNode::New (const CpuProfileNode* node) {
   Nan::Set(profile_node, Nan::New<String>("functionName").ToLocalChecked(), node->GetFunctionName());
   Nan::Set(profile_node, Nan::New<String>("url").ToLocalChecked(), node->GetScriptResourceName());
   Nan::Set(profile_node, Nan::New<String>("lineNumber").ToLocalChecked(), Nan::New<Integer>(node->GetLineNumber()));
+  Nan::Set(profile_node, Nan::New<String>("columnNumber").ToLocalChecked(), Nan::New<Integer>(node->GetColumnNumber()));
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION < 8)
   Nan::Set(profile_node, Nan::New<String>("callUID").ToLocalChecked(), Nan::New<Number>(node->GetCallUid()));
+#endif
 #if (NODE_MODULE_VERSION > 0x000B)
   Nan::Set(profile_node, Nan::New<String>("bailoutReason").ToLocalChecked(), Nan::New<String>(node->GetBailoutReason()).ToLocalChecked());
   Nan::Set(profile_node, Nan::New<String>("id").ToLocalChecked(), Nan::New<Integer>(node->GetNodeId()));


### PR DESCRIPTION
> ../src/cpu_profile_node.cc:58:95: warning: 'GetCallUid' is deprecated: Use GetScriptId, GetLineNumber, and GetColumnNumber instead.

`GetCallUid()` was [removed](https://chromium.googlesource.com/v8/v8/+/99268b15c21ac76f561cb4ec6336708ad91de759) in V8 8.0, let's add the last missing replacement – a column number.
