### PR TITLE
fix: set 'win_delay_load_hook' to 'true' for Electron 4+

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,8 @@
   'targets': [
     {
       'target_name': 'profiler',
-      'win_delay_load_hook': 'false',
+      # Electron 4+ requires this to be true
+      'win_delay_load_hook': 'true',
       'sources': [
         'src/profiler.cc',
         'src/cpu_profiler.cc',


### PR DESCRIPTION
https://www.electronjs.org/blog/electron-4-0#win_delay_load_hook
> When building native modules for windows, the win_delay_load_hook variable in the module's binding.gyp must be true (which is the default). If this hook is not present, then the native module will fail to load on Windows, with an error message like Cannot find module. See the native module guide for more information.

https://www.electronjs.org/docs/tutorial/using-native-node-modules#a-note-about-win_delay_load_hook