### PR TITLE
fix: support nodejs22 and electron32

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,7 +10,7 @@
   'targets': [
     {
       'target_name': 'profiler',
-      'win_delay_load_hook': 'false',
+      'win_delay_load_hook': 'true',
       'sources': [
         'src/cpu_profiler/cpu_profiler.cc',
         'src/cpu_profiler/cpu_profile.cc',
@@ -30,23 +30,41 @@
       ],
       'conditions':[
         ['OS == "linux"', {
-          'cflags': [
+          'cflags_cc': [
+            '-std=gnu++20',
             '-O2',
-            '-std=c++17',
             '-Wno-sign-compare',
             '-Wno-cast-function-type',
           ],
         }],
         ['OS == "mac"', {
+          'cflags_cc': [
+            '-std=c++20',
+            '-O2',
+            '-Wconversion',
+            '-Wno-sign-conversion',
+          ],
           'xcode_settings': {
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
-            'OTHER_CFLAGS': [
-              '-std=c++17',
+            'OTHER_CPLUSPLUSFLAGS': [
+              '-std=c++20',
               '-Wconversion',
               '-Wno-sign-conversion',
             ]
           }
         }],
+        ['OS == "win"', {
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'AdditionalOptions': ['/std:c++20'],
+              'ExceptionHandling': 1
+            }
+          },
+          'defines': [
+            'NOMINMAX',
+            'WIN32_LEAN_AND_MEAN'
+          ]
+        }]
       ]
     },
   ],


### PR DESCRIPTION
this is what I came to the conclusion is required to be able to run this on modern electron versions

electron devs will need to run
```
npx electron-rebuild --only=v8-profiler-next --force
```
however that's documented in electron docs, and expected to be known by the developers