### PR TITLE
add support for node v22 and v24

### DIFF
--- a/.autod.conf.js
+++ b/.autod.conf.js
@@ -8,7 +8,7 @@ module.exports = {
   ],
   dep: [
     'nan',
-    '@xprofiler/node-pre-gyp',
+    '@yrambler2001/node-pre-gyp',
   ],
   devdep: [
     'autod',

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,9 +1,9 @@
 name: Continuous integration
 on:
   push:
-    branches: [ '**' ]
+    branches: ['**']
   pull_request:
-    branches: [ '**' ]
+    branches: ['**']
   schedule:
     - cron: '0 2 * * *'
 jobs:
@@ -12,48 +12,49 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [ 12, 14, 16, 18, 20 ]
+        node-version: [18, 20, 22, 24]
     steps:
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
-    - name: Checkout Git Source
-      uses: actions/checkout@master
+      - name: Checkout Git Source
+        uses: actions/checkout@v4
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    - name: Install Dependencies
-      run: npm i
+      - name: Install Dependencies
+        run: npm i
 
-    - name: Continuous integration
-      run: npm run debug-test
+      - name: Continuous integration
+        run: npm run debug-test
+
   macos:
     runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-        node-version: [ 12, 14, 16, 18, 20 ]
+        node-version: [18, 20, 22, 24]
     steps:
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
-    - name: Checkout Git Source
-      uses: actions/checkout@master
+      - name: Checkout Git Source
+        uses: actions/checkout@v4
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    - name: Install Dependencies
-      run: npm i
+      - name: Install Dependencies
+        run: npm i
 
-    - name: Continuous integration
-      run: npm run debug-test
+      - name: Continuous integration
+        run: npm run debug-test

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -47,7 +47,7 @@ jobs:
             arch: x64
           - os: macos-14
             node-version: 24
-            arch: arm64
+            arch: x64
           # macOS arm64
           - os: macos-14
             node-version: 18
@@ -90,7 +90,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-
+          architecture: ${{ matrix.arch }}
       - name: Install dependencies
         run: npm install
 

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -1,0 +1,111 @@
+name: Prebuild and Release
+on:
+  release:
+    types: [created]
+
+jobs:
+  prebuild:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Windows x64
+          - os: windows-latest
+            node-version: 18
+            arch: x64
+          - os: windows-latest
+            node-version: 20
+            arch: x64
+          - os: windows-latest
+            node-version: 22
+            arch: x64
+          - os: windows-latest
+            node-version: 24
+            arch: x64
+          # Linux arm64
+          - os: ubuntu-24.04-arm
+            node-version: 18
+            arch: arm64
+          - os: ubuntu-24.04-arm
+            node-version: 20
+            arch: arm64
+          - os: ubuntu-24.04-arm
+            node-version: 22
+            arch: arm64
+          - os: ubuntu-24.04-arm
+            node-version: 24
+            arch: arm64
+          # macOS x64
+          - os: macos-14
+            node-version: 18
+            arch: x64
+          - os: macos-14
+            node-version: 20
+            arch: x64
+          - os: macos-14
+            node-version: 22
+            arch: x64
+          - os: macos-14
+            node-version: 24
+            arch: arm64
+          # macOS arm64
+          - os: macos-14
+            node-version: 18
+            arch: arm64
+          - os: macos-14
+            node-version: 20
+            arch: arm64
+          - os: macos-14
+            node-version: 22
+            arch: arm64
+          - os: macos-14
+            node-version: 24
+            arch: arm64
+          # Linux x64
+          - os: ubuntu-latest
+            node-version: 18
+            arch: x64
+          - os: ubuntu-latest
+            node-version: 20
+            arch: x64
+          - os: ubuntu-latest
+            node-version: 22
+            arch: x64
+          - os: ubuntu-latest
+            node-version: 24
+            arch: x64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build native module
+        run: npx node-pre-gyp rebuild
+
+      - name: Package prebuilt binary
+        run: npx node-pre-gyp package
+
+      - name: Test packaged binary
+        run: npx node-pre-gyp testpackage
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build/stage/**/*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ v8-profiler-next provides [node](https://github.com/nodejs/node) bindings for th
 ## I. Quick Start
 
 * **Compatibility**
-  * **node version:** v4.x ~ v21.x
+  * **node version:** v18.x ~ v24.x
   * **platform:** mac, linux, windows
 
 This module can also be used in `worker_threads`.

--- a/binding.gyp
+++ b/binding.gyp
@@ -30,9 +30,9 @@
       ],
       'conditions':[
         ['OS == "linux"', {
-          'cflags': [
+          'cflags_cc': [
             '-O2',
-            '-std=c++17',
+            '-std=c++20',
             '-Wno-sign-compare',
             '-Wno-cast-function-type',
           ],
@@ -40,13 +40,22 @@
         ['OS == "mac"', {
           'xcode_settings': {
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
-            'OTHER_CFLAGS': [
-              '-std=c++17',
+            'CLANG_CXX_LANGUAGE_STANDARD': 'c++20',
+            'MACOSX_DEPLOYMENT_TARGET': '12.0',
+            'OTHER_CPLUSPLUSFLAGS': [
+              '-std=c++20',
               '-Wconversion',
               '-Wno-sign-conversion',
             ]
           }
         }],
+        ['OS == "win"', {
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'AdditionalOptions': ['/std:c++20']
+            }
+          }
+        }]
       ]
     },
   ],

--- a/lib/binding.js
+++ b/lib/binding.js
@@ -8,7 +8,7 @@ if (nodeVersionLessThan(12)) {
   binding = require('../build/Release/profiler.node');
 } else {
   const path = require('path');
-  const binary = require('@xprofiler/node-pre-gyp');
+  const binary = require('@yrambler2001/node-pre-gyp');
   const bindingPath = binary.find(path.resolve(path.join(__dirname, '../package.json')));
   binding = require(bindingPath);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "v8-profiler-next",
-  "version": "1.10.0",
+  "name": "@yrambler2001/v8-profiler-next",
+  "version": "1.11.0",
   "description": "node bindings for the v8 profiler",
   "main": "dispatch.js",
   "binary": {
@@ -8,7 +8,7 @@
     "module_path": "./build/binding/{configuration}/{node_abi}-{platform}-{arch}/",
     "remote_path": "./v{version}/",
     "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}.tar.gz",
-    "host": "https://github.com/hyj1991/v8-profiler-next/releases/download"
+    "host": "https://github.com/yrambler2001/v8-profiler-next/releases/download"
   },
   "scripts": {
     "install": "node scripts/install.js",
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hyj1991/v8-profiler-next.git"
+    "url": "git+https://github.com/yrambler2001/v8-profiler-next.git"
   },
   "keywords": [
     "node",
@@ -40,9 +40,9 @@
   "author": "https://github.com/hyj1991",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/hyj1991/v8-profiler-next/issues"
+    "url": "https://github.com/yrambler2001/v8-profiler-next/issues"
   },
-  "homepage": "https://github.com/hyj1991/v8-profiler-next#readme",
+  "homepage": "https://github.com/yrambler2001/v8-profiler-next#readme",
   "files": [
     "lib",
     "scripts",
@@ -55,7 +55,7 @@
   ],
   "dependencies": {
     "@xprofiler/node-pre-gyp": "^1.0.9",
-    "nan": "^2.18.0"
+    "nan": "^2.22.0"
   },
   "devDependencies": {
     "chai": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yrambler2001/v8-profiler-next",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "node bindings for the v8 profiler",
   "main": "dispatch.js",
   "binary": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@xprofiler/node-pre-gyp": "^1.0.9",
+    "@yrambler2001/node-pre-gyp": "2.0.4",
     "nan": "^2.22.0"
   },
   "devDependencies": {

--- a/scripts/copy.js
+++ b/scripts/copy.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const fs = require('fs');
-const versioning = require('@xprofiler/node-pre-gyp/lib/util/versioning.js');
+const versioning = require('@yrambler2001/node-pre-gyp/lib/util/versioning.js');
 const packagePath = versioning.evaluate(require('../package.json')).staged_tarball;
 
 function copy() {

--- a/scripts/versions.js
+++ b/scripts/versions.js
@@ -3,16 +3,11 @@
 const os = require('os');
 
 exports.os7u = [
-  'node-v12.22.12',
-  'node-v13.14.0',
-  'node-v14.21.3',
-  'node-v15.14.0',
-  'node-v16.20.2',
   'node-v17.9.1',
 ];
 
 if (os.platform() === 'darwin' && os.arch() === 'arm64') {
-  exports.os7u = exports.os7u.slice(4);
+  exports.os7u = exports.os7u.slice(2);
 }
 
 exports.os8u = [
@@ -20,4 +15,6 @@ exports.os8u = [
   'node-v19.9.0',
   'node-v20.10.0',
   'node-v21.5.0',
+  'node-v22.12.0',
+  'node-v24.14.0',
 ];

--- a/src/heap_profiler/sampling_heap_profiler.cc
+++ b/src/heap_profiler/sampling_heap_profiler.cc
@@ -116,7 +116,7 @@ INNER_METHOD(InnerSamplingHeapProfiler::StopSamplingHeapProfiling) {
   Local<Object> result = Nan::New<Object>();
   Nan::Set(result, Nan::New<String>("head").ToLocalChecked(), js_node);
   info.GetReturnValue().Set(result);
-  free(profile);
+  delete profile;
   // stop sampling heap profile
   v8::Isolate::GetCurrent()->GetHeapProfiler()->StopSamplingHeapProfiler();
 #endif

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -69,6 +69,34 @@ function getOutput(proc) {
   });
 }
 
+function filterStderr(stderr) {
+  if (!stderr) {
+    return '';
+  }
+  // Filter out known Node.js deprecation warnings that are not errors
+  return stderr
+    .split('\n')
+    .filter(line => {
+      if (!line.trim()) {
+        return false;
+      }
+      // Ignore DeprecationWarning lines (e.g., DEP0169 for url.parse())
+      if (line.includes('DeprecationWarning:')) {
+        return false;
+      }
+      // Ignore trace-deprecation hint lines
+      if (line.includes('Use `node --trace-deprecation ...`')) {
+        return false;
+      }
+      // Ignore ExperimentalWarning lines
+      if (line.includes('ExperimentalWarning:')) {
+        return false;
+      }
+      return true;
+    })
+    .join('\n')
+    .trim();
+}
 
 
 (canIUseWorkerThreads ? describe : describe.skip)('worker_threads', function () {
@@ -92,7 +120,8 @@ function getOutput(proc) {
     });
 
     it('worker_threads should exit succeed', function () {
-      assert(!output.stderr);
+      const meaningfulStderr = filterStderr(output.stderr);
+      assert(!meaningfulStderr, `Unexpected stderr output: ${meaningfulStderr}`);
       console.log(output.stdout);
       const stdout = output.stdout.split('\n').filter(line => line && !line.match(/\[thread \d+/)).join('');
       const { code: workerExitCode } = JSON.parse(stdout);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -69,34 +69,6 @@ function getOutput(proc) {
   });
 }
 
-function filterStderr(stderr) {
-  if (!stderr) {
-    return '';
-  }
-  // Filter out known Node.js deprecation warnings that are not errors
-  return stderr
-    .split('\n')
-    .filter(line => {
-      if (!line.trim()) {
-        return false;
-      }
-      // Ignore DeprecationWarning lines (e.g., DEP0169 for url.parse())
-      if (line.includes('DeprecationWarning:')) {
-        return false;
-      }
-      // Ignore trace-deprecation hint lines
-      if (line.includes('Use `node --trace-deprecation ...`')) {
-        return false;
-      }
-      // Ignore ExperimentalWarning lines
-      if (line.includes('ExperimentalWarning:')) {
-        return false;
-      }
-      return true;
-    })
-    .join('\n')
-    .trim();
-}
 
 
 (canIUseWorkerThreads ? describe : describe.skip)('worker_threads', function () {
@@ -120,8 +92,7 @@ function filterStderr(stderr) {
     });
 
     it('worker_threads should exit succeed', function () {
-      const meaningfulStderr = filterStderr(output.stderr);
-      assert(!meaningfulStderr, `Unexpected stderr output: ${meaningfulStderr}`);
+      assert(!output.stderr);
       console.log(output.stdout);
       const stdout = output.stdout.split('\n').filter(line => line && !line.match(/\[thread \d+/)).join('');
       const { code: workerExitCode } = JSON.parse(stdout);


### PR DESCRIPTION
`npm i @yrambler2001/v8-profiler-next`

npm https://www.npmjs.com/package/@yrambler2001/v8-profiler-next

tag with artifacts for node 18/20/22/24 darwin-arm64/darwin-x64/linux-arm64/linux-x64/win32-x64 https://github.com/yrambler2001/v8-profiler-next/releases/tag/v1.11.1

test ci https://github.com/yrambler2001/v8-profiler-next/actions/runs/22982104364

artifact ci https://github.com/yrambler2001/v8-profiler-next/actions/runs/22981966800

merge request https://github.com/hyj1991/v8-profiler-next/pull/77

includes updated node-pre-gyp v2.0.4 https://github.com/mapbox/node-pre-gyp/pull/947